### PR TITLE
Actually load up environment when calling binary wrappers.

### DIFF
--- a/.bin/ocaml
+++ b/.bin/ocaml
@@ -136,4 +136,4 @@ if [ "$actual_path" == "" ] || [ "$actual_path" == "$source" ]; then
   exit 1
 fi
 
-$(echo $actual_path) "$@"
+$scriptdir/../node_modules/.bin/esy $(echo $actual_path) "$@"

--- a/.bin/ocamlc
+++ b/.bin/ocamlc
@@ -136,4 +136,4 @@ if [ "$actual_path" == "" ] || [ "$actual_path" == "$source" ]; then
   exit 1
 fi
 
-$(echo $actual_path) "$@"
+$scriptdir/../node_modules/.bin/esy $(echo $actual_path) "$@"

--- a/.bin/ocamlmerlin
+++ b/.bin/ocamlmerlin
@@ -136,4 +136,4 @@ if [ "$actual_path" == "" ] || [ "$actual_path" == "$source" ]; then
   exit 1
 fi
 
-$(echo $actual_path) "$@"
+$scriptdir/../node_modules/.bin/esy $(echo $actual_path) "$@"

--- a/.bin/ocamlmerlin-reason
+++ b/.bin/ocamlmerlin-reason
@@ -136,4 +136,4 @@ if [ "$actual_path" == "" ] || [ "$actual_path" == "$source" ]; then
   exit 1
 fi
 
-$(echo $actual_path) "$@"
+$scriptdir/../node_modules/.bin/esy $(echo $actual_path) "$@"

--- a/.bin/ocamlopt
+++ b/.bin/ocamlopt
@@ -136,4 +136,4 @@ if [ "$actual_path" == "" ] || [ "$actual_path" == "$source" ]; then
   exit 1
 fi
 
-$(echo $actual_path) "$@"
+$scriptdir/../node_modules/.bin/esy $(echo $actual_path) "$@"

--- a/.bin/ocamlrun
+++ b/.bin/ocamlrun
@@ -136,4 +136,4 @@ if [ "$actual_path" == "" ] || [ "$actual_path" == "$source" ]; then
   exit 1
 fi
 
-$(echo $actual_path) "$@"
+$scriptdir/../node_modules/.bin/esy $(echo $actual_path) "$@"

--- a/.bin/reactjs_jsx_ppx
+++ b/.bin/reactjs_jsx_ppx
@@ -136,5 +136,5 @@ if [ "$actual_path" == "" ] || [ "$actual_path" == "$source" ]; then
   exit 1
 fi
 
-$(echo $actual_path) "$@"
+$scriptdir/../node_modules/.bin/esy $(echo $actual_path) "$@"
 

--- a/.bin/rebuild
+++ b/.bin/rebuild
@@ -136,4 +136,4 @@ if [ "$actual_path" == "" ] || [ "$actual_path" == "$source" ]; then
   exit 1
 fi
 
-$(echo $actual_path) "$@"
+$scriptdir/../node_modules/.bin/esy $(echo $actual_path) "$@"

--- a/.bin/refmt
+++ b/.bin/refmt
@@ -136,4 +136,4 @@ if [ "$actual_path" == "" ] || [ "$actual_path" == "$source" ]; then
   exit 1
 fi
 
-$(echo $actual_path) "$@"
+$scriptdir/../node_modules/.bin/esy $(echo $actual_path) "$@"

--- a/.bin/refmt_merlin
+++ b/.bin/refmt_merlin
@@ -136,4 +136,4 @@ if [ "$actual_path" == "" ] || [ "$actual_path" == "$source" ]; then
   exit 1
 fi
 
-$(echo $actual_path) "$@"
+$scriptdir/../node_modules/.bin/esy $(echo $actual_path) "$@"

--- a/.bin/refmttype
+++ b/.bin/refmttype
@@ -136,4 +136,4 @@ if [ "$actual_path" == "" ] || [ "$actual_path" == "$source" ]; then
   exit 1
 fi
 
-$(echo $actual_path) "$@"
+$scriptdir/../node_modules/.bin/esy $(echo $actual_path) "$@"

--- a/.bin/reopt
+++ b/.bin/reopt
@@ -136,4 +136,4 @@ if [ "$actual_path" == "" ] || [ "$actual_path" == "$source" ]; then
   exit 1
 fi
 
-$(echo $actual_path) "$@"
+$scriptdir/../node_modules/.bin/esy $(echo $actual_path) "$@"

--- a/.bin/rtop
+++ b/.bin/rtop
@@ -137,4 +137,4 @@ if [ "$actual_path" == "" ] || [ "$actual_path" == "$source" ]; then
   exit 1
 fi
 
-$(echo $actual_path) "$@"
+$scriptdir/../node_modules/.bin/esy $(echo $actual_path) "$@"

--- a/.bin/utop
+++ b/.bin/utop
@@ -136,4 +136,4 @@ if [ "$actual_path" == "" ] || [ "$actual_path" == "$source" ]; then
   exit 1
 fi
 
-$(echo $actual_path) "$@"
+$scriptdir/../node_modules/.bin/esy $(echo $actual_path) "$@"


### PR DESCRIPTION
Summary:

Some environment variables need to be set when invoking the binary
wrappers. This is to load dynamic libraries LD_LIBRARY_PATH.

There's downsides:
1. This is slow to start binaries (extra 100ms?)
2. This is somewhat of an abuse of the environment variables.  The
exported env vars are only intended on being for build time.  We really
want a new class of env vars that are set when *running* resulting
binaries. I've documented that
[here](https://github.com/jordwalke/PackageJsonForCompilers/blob/master/FutureImprovements.md#runtime-environment-variables).

But it's not so bad: Because the binaries that actually have to be have
their symlinks fixed up at install time for this -g package, and they
happen to not depend on any env vars at runtime.

Test Plan:Travis.

Reviewers:

CC: