### PR TITLE
Bump Reason to 2.0.0

### DIFF
--- a/actualInstall/package.json
+++ b/actualInstall/package.json
@@ -17,7 +17,6 @@
     "ocamlc",
     "refmt",
     "berror"
-
   ],
   "author": "Jordan",
   "license": "MIT",
@@ -26,7 +25,7 @@
   },
   "homepage": "https://github.com/reasonml/reason-cli#readme",
   "dependencies": {
-    "@opam-alpha/reason": "1.13.5",
+    "@opam-alpha/reason": "2.0.0",
     "ocaml": "esy-ocaml/ocaml#esy",
     "ocamlBetterErrors": "esy-ocaml/BetterErrors#esy",
     "@opam-alpha/merlin": "2.5.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reason-cli",
-  "version": "1.13.5",
+  "version": "2.0.0",
   "preferGlobal": false,
   "description": "Globally Installable CLI Tools For ReasonML",
   "main": "index.js",
@@ -47,6 +47,6 @@
   ],
   "homepage": "https://github.com/reasonml/reason-cli#readme",
   "dependencies": {
-    "esy": "git://github.com/esy-ocaml/esy.git#beta-v0.0.4"
+    "esy": "git://github.com/esy-ocaml/esy.git#beta-v0.0.5"
   }
 }

--- a/releaseUtils/release.js
+++ b/releaseUtils/release.js
@@ -312,7 +312,7 @@ var createPostinstallScript = function(releaseStage, releaseType, package, build
         // Really they both should have the padding.
         `
         if [ -z "\${ESY_EJECT__STORE+x}" ]; then
-          export ESY_EJECT__STORE="$HOME/.esy/store-$ESY__STORE_VERSION"
+          export ESY_EJECT__STORE="$HOME/.esy/$ESY__STORE_VERSION"
         fi
         `
     }


### PR DESCRIPTION
Also fixes store name from `store-3.x.x` to `3.x.x` to adhere to recent changes to Esy.