### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ to uninstall the package first. Updating should be fairly fast, even in the case
 
 ```
 npm uninstall -g reason-cli
-npm install -g git://github.com/reasonml/reason-cli.git#beta--v-1.13.6-bin-darwin
+npm install -g git://github.com/reasonml/reason-cli.git#beta-v-1.13.6-bin-darwin
 ```
 # Usage
 


### PR DESCRIPTION
The double `-` causes the npm install to fail because:
```
macbook-pro-15:~ hugo$ npm install -g git://github.com/reasonml/reason-cli.git#beta--v-1.13.6-bin-darwin
npm ERR! git rev-list -n1 beta--v-1.13.6-bin-darwin: fatal: ambiguous argument 'beta--v-1.13.6-bin-darwin': unknown revision or path not in the working tree.
npm ERR! git rev-list -n1 beta--v-1.13.6-bin-darwin: Use '--' to separate paths from revisions, like this:
npm ERR! git rev-list -n1 beta--v-1.13.6-bin-darwin: 'git <command> [<revision>...] -- [<file>...]'
npm ERR! git rev-list -n1 beta--v-1.13.6-bin-darwin: 
npm ERR! Darwin 16.6.0
npm ERR! argv "/usr/local/var/nvm/versions/node/v7.10.0/bin/node" "/usr/local/var/nvm/versions/node/v7.10.0/bin/npm" "install" "-g" "git://github.com/reasonml/reason-cli.git#beta--v-1.13.6-bin-darwin"
npm ERR! node v7.10.0
npm ERR! npm  v4.2.0

npm ERR! Cannot read property 'path' of null
npm ERR! 
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/hugo/.npm/_logs/2017-06-21T22_14_18_680Z-debug.log
```