### PR TITLE
Quote arguments to binaryName

### DIFF
--- a/releaseUtils/release.js
+++ b/releaseUtils/release.js
@@ -208,7 +208,7 @@ ${
   if [ "$1" == "----where" ]; then
      which "${binaryName}"
   else
-    exec "${binaryName}" $@
+    exec "${binaryName}" "$@"
   fi
   ` :
   `


### PR DESCRIPTION
We were having some issues in quoting the arguments to the binary, this seems to fix it.  It's possible I'm being a moron though... I'm surprised no one had ever run into this.

Before:
```
> ocamlopt -pp 'refmt --print=binary' -impl t.re
/usr/local/lib/node_modules/reason-cli/rel/3.x.x________________________________________/i/ocaml-4.02.3-d8a857f3/bin/ocamlopt: unknown option '--print=binary'.
```

After.. it works.
This is mostly based on https://stackoverflow.com/questions/1695819/pass-bash-script-parameters-to-sub-process-unchanged