### PR TITLE
Update location of postinstall.sh script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ export SHELL="$PREV_SHELL"
 
       npm install -g whateverReasonCliReleaseYouTried --ignore-scripts
       cd whereverYourGlobalNpmPackagesAreStored/reason-cli/
-      ./scripts/postinstall.sh
+      ./postinstall.sh
 
   - Does it give any better information about what is failing?
   - Is there a specific log file that it claims the actual error is written into?


### PR DESCRIPTION
As of reason-cli 1.13.7 it appears that postintall.sh is located in the main package folder, not the scripts sub-folder.