### PR TITLE
Distribute Esy along with Reason-CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,92 @@
+ESY_VERSION = $(shell esy version)
+
 ifeq ($(TYPE), bin)
 	RELEASE_TAG = "bin-$(shell uname | tr A-Z a-z)"
 else
 	RELEASE_TAG = $(TYPE)
 endif
 
+RELEASE_DIR = _release/$(RELEASE_TAG)
+
 clean:
 	@rm -rf _release
 
 build-release:
+ifndef NO_UNSTAGED_CHECK
 	@# Program "fails" if unstaged changes.
 	@git diff --exit-code || (echo "" && echo "!!You have unstaged changes. Please clean up first." && exit 1)
 	@git diff --cached --exit-code || (echo "" && echo "!!You have staged changes. Please reset them or commit them first." && exit 1);
+endif
 	@esy release $(TYPE)
+	@cp ./Makefile $(RELEASE_DIR)/Makefile
+	@cp ./bin/esy $(RELEASE_DIR)/.bin/esy
+	@make \
+		TYPE="$(TYPE)" \
+		-C "$(RELEASE_DIR)" \
+		_build-release
+
+_build-release:
+	@echo "*** Adding esy as a bundled dependency..."
+	@npm install --global --prefix _esyInstallation "esy@$(ESY_VERSION)"
+	@tar -czf _esyInstallation.tar.gz _esyInstallation
+	@rm -rf _esyInstallation
+	@echo "$$POSTINSTALL_EXTRA" >> ./postinstall.sh
+	@node -e "$$ADD_ESY_BIN_SCRIPT"
 
 # Releases to Github
 release: build-release
-	@cp ./Makefile _release/$(RELEASE_TAG)/
 	@make \
 		RELEASE_TAG="$(RELEASE_TAG)" \
 		ORIGIN=`git remote get-url origin` \
 		VERSION=`node -p "require('./package.json').version"` \
-		-C _release/$(RELEASE_TAG) \
-		_release_continue
+		-C "$(RELEASE_DIR)" \
+		_release
+
+# This should only be called by `release` target
+_release:
+	@echo "$$WELCOME_MSG"
+	@git init .
+	@git checkout -b branch-$(VERSION)-$(RELEASE_TAG)
+	@git add .
+	@git remote add origin $(ORIGIN)
+	@git fetch --tags --depth=1
+	@git commit -m "Preparing release $(VERSION)-$(RELEASE_TAG)"
+	@# Return code is inverted to receive boolean return value',
+	@(git tag --delete "$(VERSION)-$(RELEASE_TAG)" &> /dev/null) \
+	 	|| echo "Tag $(VERSION)-$(RELEASE_TAG) doesn't yet exist, creating it now."
+	@git tag -a "$(VERSION)-$(RELEASE_TAG)" -m "$(VERSION)-$(RELEASE_TAG)"
+	@echo "$$ALMOST_DONE_MSG"
+
+
+define ADD_ESY_BIN_SCRIPT
+	var fs = require('fs');
+	var pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+	pkg.bin.esy = './.bin/esy'
+	fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2));
+endef
+export ADD_ESY_BIN_SCRIPT
+
+define POSTINSTALL_EXTRA
+
+#
+# Unpack esy installation
+#
+
+gunzip "_esyInstallation.tar.gz"
+if hash bsdtar 2>/dev/null; then
+	bsdtar -xf "_esyInstallation.tar"
+else
+	if hash tar 2>/dev/null; then
+		# Supply --warning=no-unknown-keyword to supresses warnings when packed on OSX
+		tar --warning=no-unknown-keyword -xf "_esyInstallation.tar"
+	else
+		echo >&2 "Installation requires either bsdtar or tar - neither is found.  Aborting.";
+	fi
+fi
+rm -rf "_esyInstallation.tar"
+
+endef
+export POSTINSTALL_EXTRA
 
 define WELCOME_MSG
 
@@ -38,10 +103,10 @@ define ALMOST_DONE_MSG
 -- Almost Done. Complete the following two steps
 ----------------------------------------------------
 
-Directory _release/$(RELEASE_TAG) contains a git repository ready
+Directory $(RELEASE_DIR) contains a git repository ready
 to be pushed under a tag to remote.
 
-1. [REQUIRED] cd _release/$(RELEASE_TAG)
+1. [REQUIRED] cd $(RELEASE_DIR)
 
 2. git show HEAD
 		Make sure you approve of what will be pushed to tag $(VERSION)-$(RELEASE_TAG)
@@ -60,17 +125,3 @@ You can test install the release by running:
 
 endef
 export ALMOST_DONE_MSG
-
-_release_continue:
-	@echo "$$WELCOME_MSG"
-	@git init .
-	@git checkout -b branch-$(VERSION)-$(RELEASE_TAG)
-	@git add .
-	@git remote add origin $(ORIGIN)
-	@git fetch --tags --depth=1
-	@git commit -m "Preparing release $(VERSION)-$(RELEASE_TAG)"
-	@# Return code is inverted to receive boolean return value',
-	@(git tag --delete "$(VERSION)-$(RELEASE_TAG)" &> /dev/null) \
-	 	|| echo "Tag $(VERSION)-$(RELEASE_TAG) doesn't yet exist, creating it now."
-	@git tag -a "$(VERSION)-$(RELEASE_TAG)" -m "$(VERSION)-$(RELEASE_TAG)"
-	@echo "$$ALMOST_DONE_MSG"

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ in your path:
 - `ocamlrun`
 - `ocamlc`/`ocamlopt`
 - `ocamlfind`
+- `esy`
+
+#### Inlcuded Binaries: `esy`
+
+reason-cli distribution comes with a tool called [esy][], a package.json
+workflow for compiled languages.Refer to its [documentation][esy] for the usage
+instructions.
+
+[Esy]: https://github.com/esy-ocaml/esy-core
 
 ## Advanced
 
@@ -71,7 +80,7 @@ There are also two other types of releases, `dev` and `pack`.
 
 ### Releasing
 
-You need `esy@0.0.16` (at least) installed globally:
+You need `esy@0.0.21` (at least) installed globally:
 
 ```sh
 npm install -g esy

--- a/bin/esy
+++ b/bin/esy
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+#
+# Define $SCRIPTDIR
+#
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$SCRIPTDIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+PACKAGE_ROOT="$(dirname $SCRIPTDIR)"
+ESY_COMMAND="$PACKAGE_ROOT/_esyInstallation/bin/esy"
+
+REL_ESY__PREFIX="$PACKAGE_ROOT/rel"
+DST_ESY__PREFIX="$HOME/.esy"
+
+if [ ! -d "$DST_ESY__PREFIX" ]; then
+
+  ESY_EJECT__ROOT="$REL_ESY__PREFIX/_esyEjectRoot"
+
+  REL_ESY__STORE=$(ESY__PREFIX="$REL_ESY__PREFIX" $ESY_COMMAND config get store-path)
+  DST_ESY__STORE=$(ESY__PREFIX="$DST_ESY__PREFIX" $ESY_COMMAND config get store-path)
+
+  TMP_ESY__PREFIX=$(mktemp -d)
+  TMP_ESY__STORE="$TMP_ESY__PREFIX/s"
+
+  cp -rf $REL_ESY__STORE $TMP_ESY__STORE
+
+  find $TMP_ESY__STORE -type f -print0 \
+    | xargs -0 -I '{}' -P 30 $ESY_EJECT__ROOT/bin/fastreplacestring.exe "{}" "$REL_ESY__STORE" "$DST_ESY__STORE"
+
+  mkdir "$DST_ESY__PREFIX"
+  mv "$TMP_ESY__STORE" "$DST_ESY__STORE"
+  rm -rf "$TMP_ESY__PREFIX"
+fi
+
+exec "$ESY_COMMAND" "$@"


### PR DESCRIPTION
**DO NOT MERGE YET: let's have a discussion first**

# How does it work

1. Reason CLI release packages ship with a bundled Esy installation inside.
2. Reason CLI exposes `esy` executable which (a) **optionally** relocates Reason CLI artefacts and then (b) executes real a `esy` executable found in a bundled installation.

What does it mean **optionally**? It relocates only if `~/.esy` isn't present, otherwise we assume that Esy is already installed (and most likely contain most of Reason CLI built artefacts) and do nothing. That means `esy` from Reason CLI is *only useful for those users who didn't install esy themselves*.

## Why `esy` installation is bundled with the release packages?

The main reason not to use npm `"dependencies"` and depend on Esy in a regular way was that it's hard to locate the `esy` executable in that case (especially given the differences in global installs between npm and yarn).

One way would be to use `node -p "require.resolve(...)"` but that means imposing Node runtime startup toll on any `esy` invocation.

Also in case of a bundled Esy installation we still have no deps in reason-cli package. That means `pack` and `bin` releases still consist of a single tarball which can be installed offline. Though that might be less of an advantage as yarn/npm offline capabilities improved since (are they really?).

## How `esy` installation is bundled

The way we bundle an Esy installation is a little bit hacky: 

1. we do `npm install -g --prefix _esyInstallation esy` in release dir before packing it.
2. we produce a `.tgz` out of `_esyInstallation`

Why? npm doesn't allow to include `node_modules` directories (even nested ones) inside packages unless you have `bundledDependencies` but those don't work the same between npm and yarn.

## Questions / notes

1. If `esy` package is installed then `reason-cli` release package will overwrite `esy` executable from the `esy` package.
2. There could be probably a better check performed to test if need to relocate Reason CLI artefacts to `~/.esy` (now it checks just for the existence of `~/.esy`). But such check should also be performant as it is performed on each invocation of `esy`.