### PR TITLE
Update readme - non-installed packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,6 @@ in your path:
 - `ocamlmerlin`
 - `ocamlmerlin-reason`
 - `refmt`
-- `ocamlrun`
-- `ocamlc`/`ocamlopt`
-- `ocamlfind`
-
-**Note**: `ocamlrun`, `ocamlc`, `ocamlopt`,and `ocamlfind` are no longer installed in version 3.1.0.
 
 ## Advanced
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ in your path:
 - `ocamlc`/`ocamlopt`
 - `ocamlfind`
 
+**Note**: `ocamlrun`, `ocamlc`, `ocamlopt`,and `ocamlfind` are no longer installed in version 3.1.0.
+
 ## Advanced
 
 ### Optional `dev`/`pack` releases:


### PR DESCRIPTION
The latest version does not install the following packages:
- `ocamlrun`
- `ocamlc`/`ocamlopt`
- `ocamlfind`

I decided to keep them there and rather add a note, since maybe the intension is to add them back at some point in future versions? Let me know, I can remove them from the list too.